### PR TITLE
Explicitly add ostype to  az container create

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -33,7 +33,7 @@ elseif ($runnerOs -eq "Windows") {
     $packageTag = "Package=$tagName"
     $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
 
-    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public"
+    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public --os-type Linux"
 
     if ($registryUser -and $registryPass) {
         Write-Output "Creating container with login to $registryLoginServer"

--- a/setup.ps1
+++ b/setup.ps1
@@ -33,7 +33,7 @@ elseif ($runnerOs -eq "Windows") {
     $packageTag = "Package=$tagName"
     $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
 
-    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public --os-type Linux"
+    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public"
 
     if ($registryUser -and $registryPass) {
         Write-Output "Creating container with login to $registryLoginServer"


### PR DESCRIPTION
The [ CI build for RabbitMQ](https://github.com/Particular/NServiceBus.RabbitMQ/actions/runs/12034838549/job/33553105629?pr=1510) failed with the following error : 

ERROR: (InvalidOsType) The 'osType' for container group '<null>' is invalid. The value must be one of 'Windows,Linux'.
Code: InvalidOsType
Message: The 'osType' for container group '<null>' is invalid. The value must be one of 'Windows,Linux'.

This PR addresses the error by explicitly specifying the ostype while creating the azure container. The os-type has been defaulted to use Linux as Rabbitmq images do not have a windows variant