### PR TITLE
Support for passing args value to RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This action handles the setup and teardown of a RabbitMQ container for running t
           registry-login-server: index.docker.io
           registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
           registry-password: ${{ secrets.DOCKERHUB_TOKEN }}}}
+          erl-args: -rabbitmq_management path_prefix "/my-prefix"
 ```
 
 `connection-string-name` and `tag` are required. `host-env-var-name`, and `imageTag` are optional.
@@ -23,6 +24,10 @@ For logging into a container registry:
 
 * `registry-login-server` defaults to `index.docker.io` and is not required if logging into Docker Hub.
 * `registry-username` and `registry-password` are optional and will result in pulling the RabbitMQ container anonymously if omitted.
+
+## RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+
+Use `erl-args` to pass arguments to the `RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS` environment variable.
 
 ## Development
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   registry-password:
     description: The password to log in to the container registry. Will not attempt login if not provided.
     required: false
+  erl-args:
+    description: Additional arguments passed to RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+    required: false
 
 runs:
   using: node20

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ let imageTag = core.getInput('image-tag');
 let registryLoginServer = core.getInput('registry-login-server');
 let registryUser = core.getInput('registry-username');
 let registryPass = core.getInput('registry-password');
+let erlArgs = core.getInput('erl-args');
 
 async function run() {
 
@@ -43,7 +44,8 @@ async function run() {
                 '-imageTag', imageTag,
                 '-registryLoginServer', registryLoginServer,
                 '-registryUser', registryUser,
-                '-registryPass', registryPass
+                '-registryPass', registryPass,
+                '-erlArgs', erlArgs
             ]);
 
         } else { // Cleanup

--- a/setup.ps1
+++ b/setup.ps1
@@ -6,7 +6,8 @@ param (
     [string]$imageTag,
     [string]$registryLoginServer,
     [string]$registryUser,
-    [string]$registryPass
+    [string]$registryPass,
+    [string]$erlArgs
 )
 
 $dockerImage = "rabbitmq:$imageTag"
@@ -17,10 +18,18 @@ $ipAddress = "127.0.0.1"
 if ($runnerOs -eq "Linux") {
     Write-Output "Running Rabbit in container $($containerName) using Docker"
 
-    docker run --name "$($hostname)" -d -p "5672:5672" -p "15672:15672" $dockerImage
+    if ($erlArgs) {
+        $erlArgs = "-e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=$managementPathPrefix"
+    }
+
+    docker run --name "$($hostname)" -d -p "5672:5672" -p "15672:15672" $managementPathPrefix $dockerImage
 }
 elseif ($runnerOs -eq "Windows") {
 
+    if ($erlArgs) {
+        $erlArgs = "--environment-variables RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=$managementPathPrefix"
+    }
+    
     if ($Env:REGION_OVERRIDE) {
         $region = $Env:REGION_OVERRIDE
     }
@@ -33,7 +42,7 @@ elseif ($runnerOs -eq "Windows") {
     $packageTag = "Package=$tagName"
     $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
 
-    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public --os-type Linux"
+    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public --os-type Linux $managementPathPrefix"
 
     if ($registryUser -and $registryPass) {
         Write-Output "Creating container with login to $registryLoginServer"

--- a/setup.ps1
+++ b/setup.ps1
@@ -19,15 +19,15 @@ if ($runnerOs -eq "Linux") {
     Write-Output "Running Rabbit in container $($containerName) using Docker"
 
     if ($erlArgs) {
-        $erlArgs = "-e RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=$managementPathPrefix"
+        $erlArgs = "-e 'RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=$erlArgs'"
     }
 
-    docker run --name "$($hostname)" -d -p "5672:5672" -p "15672:15672" $managementPathPrefix $dockerImage
+    docker run --name "$($hostname)" -d -p "5672:5672" -p "15672:15672" $erlArgs $dockerImage
 }
 elseif ($runnerOs -eq "Windows") {
 
     if ($erlArgs) {
-        $erlArgs = "--environment-variables RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=$managementPathPrefix"
+        $erlArgs = "-e 'RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=$erlArgs'"
     }
     
     if ($Env:REGION_OVERRIDE) {
@@ -42,7 +42,7 @@ elseif ($runnerOs -eq "Windows") {
     $packageTag = "Package=$tagName"
     $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
 
-    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public --os-type Linux $managementPathPrefix"
+    $azureContainerCreate = "az container create --image $dockerImage --name $hostname --location $region --dns-name-label $hostname --resource-group $resourceGroup --cpu 4 --memory 16 --ports 5672 15672 --ip-address public --os-type Linux $erlArgs"
 
     if ($registryUser -and $registryPass) {
         Write-Output "Creating container with login to $registryLoginServer"


### PR DESCRIPTION
This should allow passing a value like `-rabbitmq_management path_prefix "/my-prefix"` to help testing certain advanced RabbitMQ settings